### PR TITLE
Fix DB connection context manager

### DIFF
--- a/src/database/connection.py
+++ b/src/database/connection.py
@@ -4,7 +4,6 @@ Módulo de conexión a base de datos SQLite
 
 import sqlite3
 import logging
-import time
 from pathlib import Path
 from typing import Optional
 from contextlib import contextmanager
@@ -41,7 +40,7 @@ class DatabaseConnection:
     def get_connection(self):
         """
         Context manager para obtener conexión a la base de datos.
-        Reutiliza la conexión si ya existe una en el mismo hilo.
+        Siempre abre una nueva conexión y la cierra al finalizar.
         
         Yields:
             sqlite3.Connection: Conexión activa
@@ -50,11 +49,6 @@ class DatabaseConnection:
             DatabaseConnectionError: Error al conectar a la base de datos
             DatabaseTimeoutError: Timeout al conectar a la base de datos
         """
-        # Si ya hay una conexión activa en este hilo, la reutilizamos
-        if hasattr(self._local, 'connection') and self._local.connection is not None:
-            yield self._local.connection
-            return
-
         conn = None
         try:
             # Conectar con timeout explícito


### PR DESCRIPTION
## Summary
- ensure `DatabaseConnection.get_connection` always opens and closes a connection
- update the docstring accordingly

## Testing
- `pytest tests/unit/test_music_service.py::test_search_songs tests/unit/test_music_service.py::test_pagination -q`

------
https://chatgpt.com/codex/tasks/task_e_684425615568832e96161b6c278d16cd