### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ python scripts/test_recursion_fix.py
 
 ## 🛡️ Corrección del RecursionError
 
-Este proyecto incluye una corrección comprehensiva para el `RecursionError: maximum recursion depth exceeded` que ocurría en el método `load_songs_for_library_view`.
+Este proyecto incluye una corrección comprensiva para el `RecursionError: maximum recursion depth exceeded` que ocurría en el método `load_songs_for_library_view`.
 
 ### Problema Original
 - **Causa:** `QMessageBox.critical()` modal interfería con el bucle de eventos de Qt


### PR DESCRIPTION
## Summary
- fix a typo in the recursion section of `README.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', 'PyQt6', 'mutagen')*

------
https://chatgpt.com/codex/tasks/task_e_6844272eda70832e94a5f89e89247328