### PR TITLE
Fix BaseService update timestamp

### DIFF
--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -4,6 +4,7 @@ Servicio base para lógica de negocio
 
 import logging
 from abc import ABC, abstractmethod
+from datetime import datetime
 from typing import List, Optional, Dict, Any
 from database.connection import DatabaseConnection
 
@@ -134,7 +135,7 @@ class BaseService(ABC):
                 return False
             
             # Agregar timestamp de actualización
-            filtered_data['updated_at'] = 'CURRENT_TIMESTAMP'
+            filtered_data['updated_at'] = datetime.utcnow().isoformat()
             
             # Construir query de actualización
             set_clause = ', '.join([f"{field} = ?" for field in filtered_data.keys()])


### PR DESCRIPTION
## Summary
- import `datetime` in `BaseService`
- use `datetime.utcnow().isoformat()` when setting `updated_at`

## Testing
- `pytest -q` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_684427146354832eb7d6c002284235e1