### PR TITLE
Fix BPM extraction for M4A

### DIFF
--- a/src/services/metadata_extractor.py
+++ b/src/services/metadata_extractor.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from mutagen import File as MutagenFile
 from mutagen.easyid3 import EasyID3
+from mutagen.mp4 import MP4
 
 from ..models.song import Song
 
@@ -15,40 +16,60 @@ class MetadataExtractor:
     def extract(self, file_path: Path) -> Optional[Song]:
         """Return a Song with metadata from ``file_path`` or ``None`` if not found."""
         try:
-            audio = MutagenFile(file_path, easy=True)
+            audio = MutagenFile(file_path)
             if audio is None:
                 return None
 
-            if isinstance(audio, EasyID3):
-                title = audio.get("title", [file_path.stem])[0] or file_path.stem
-                artist = audio.get("artist", ["Desconocido"])[0]
-                album = audio.get("album", ["Sin álbum"])[0]
-                genre = audio.get("genre", ["Sin género"])[0]
-                bpm = None
-                if "bpm" in audio:
+            title = file_path.stem
+            artist = "Desconocido"
+            album = "Sin álbum"
+            genre = "Sin género"
+            bpm = None
+
+            # Special handling for MP4/M4A files
+            if isinstance(audio, MP4):
+                tags = audio.tags or {}
+                title = tags.get("\xa9nam", [file_path.stem])[0]
+                artist = tags.get("\xa9ART", ["Desconocido"])[0]
+                album = tags.get("\xa9alb", ["Sin álbum"])[0]
+                genre = tags.get("\xa9gen", ["Sin género"])[0]
+
+                if "tmpo" in tags:
                     try:
-                        bpm = int(float(audio["bpm"][0]))
-                    except (ValueError, IndexError):
-                        pass
+                        bpm = int(tags["tmpo"][0])
+                    except (ValueError, IndexError, TypeError):
+                        bpm = None
+                elif "----:com.apple.iTunes:BPM" in tags:
+                    try:
+                        raw = tags["----:com.apple.iTunes:BPM"][0]
+                        if isinstance(raw, bytes):
+                            raw = raw.decode("utf-8", "ignore")
+                        bpm = int(raw)
+                    except (ValueError, IndexError, TypeError):
+                        bpm = None
             else:
-                tags = audio.tags
-                if tags:
+                easy = MutagenFile(file_path, easy=True)
+                if easy is not None and isinstance(getattr(easy, "tags", None), EasyID3):
+                    title = easy.tags.get("title", [file_path.stem])[0] or file_path.stem
+                    artist = easy.tags.get("artist", ["Desconocido"])[0]
+                    album = easy.tags.get("album", ["Sin álbum"])[0]
+                    genre = easy.tags.get("genre", ["Sin género"])[0]
+                    if "bpm" in easy.tags:
+                        try:
+                            bpm = int(float(easy.tags["bpm"][0]))
+                        except (ValueError, IndexError):
+                            bpm = None
+                elif audio.tags:
+                    tags = audio.tags
                     title = str(tags.get("title", [file_path.stem])[0])
                     artist = str(tags.get("artist", ["Desconocido"])[0])
                     album = str(tags.get("album", ["Sin álbum"])[0])
                     genre = str(tags.get("genre", ["Sin género"])[0])
-                    bpm = None
                     if "bpm" in tags:
                         try:
                             bpm = int(float(str(tags["bpm"][0])))
                         except (ValueError, IndexError):
-                            pass
-                else:
-                    title = file_path.stem
-                    artist = "Desconocido"
-                    album = "Sin álbum"
-                    genre = "Sin género"
-                    bpm = None
+                            bpm = None
 
             return Song(
                 id=None,

--- a/tests/unit/test_metadata_extractor_m4a.py
+++ b/tests/unit/test_metadata_extractor_m4a.py
@@ -1,0 +1,47 @@
+"""Tests for MetadataExtractor with M4A files."""
+
+import os
+from pathlib import Path
+import pytest
+
+pytest.importorskip("mutagen")
+pytest.importorskip("scipy")
+pytest.importorskip("numpy")
+
+from scipy.io import wavfile
+import numpy
+from mutagen.mp4 import MP4
+
+from src.services.metadata_extractor import MetadataExtractor
+
+
+def test_extract_m4a_bpm(tmp_path):
+    wav_path = tmp_path / "temp.wav"
+    m4a_path = tmp_path / "temp.m4a"
+
+    sample_rate = 44100
+    duration = 1.0
+    t = numpy.linspace(0, duration, int(sample_rate * duration))
+    data = numpy.sin(2 * numpy.pi * 440 * t)
+    data = numpy.int16(data * 32767)
+    wavfile.write(wav_path, sample_rate, data)
+
+    os.system(
+        f'ffmpeg -i "{wav_path}" -codec:a aac -b:a 192k "{m4a_path}" -y -hide_banner -loglevel panic'
+    )
+    wav_path.unlink()
+
+    audio = MP4(m4a_path)
+    audio["\xa9nam"] = ["M4A Title"]
+    audio["\xa9ART"] = ["M4A Artist"]
+    audio["tmpo"] = [130]
+    audio.save()
+
+    extractor = MetadataExtractor()
+    song = extractor.extract(m4a_path)
+
+    assert song is not None
+    assert song.title == "M4A Title"
+    assert song.artist == "M4A Artist"
+    assert song.bpm == 130
+    assert song.file_path == m4a_path


### PR DESCRIPTION
## Summary
- parse MP4/M4A tags in `MetadataExtractor` so BPM is read from `tmpo` or Apple BPM tag
- add unit test ensuring BPM metadata is extracted from m4a files

## Testing
- `pytest tests/unit/test_metadata_extractor.py tests/unit/test_metadata_extractor_m4a.py -q`
- `pytest -q` *(fails: not enough values to unpack, recursion prevention tests)*

------
https://chatgpt.com/codex/tasks/task_e_684608779150832e829cc877475a2cff