### PR TITLE
Centralize fonts and headless Qt setup

### DIFF
--- a/src/ui/styles/typography.py
+++ b/src/ui/styles/typography.py
@@ -2,11 +2,13 @@
 
 # Implements Dart AI Task: Extract typography configuration
 
+from ..config import UIConfig
+
+
 def get_fonts() -> dict:
-    """Return MD3 font definitions."""
-    default_font = "Roboto"
-    fallback_font = "Arial"
-    font_family = f"{default_font}, {fallback_font}"
+    """Return MD3 font definitions using the configured font family."""
+    # Centralizar la familia de fuentes para toda la aplicación
+    font_family = UIConfig.FONT_FAMILY
 
     return {
         # Display

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ Configuración global de pytest
 """
 
 import sys
+import os
 import pytest
 from pathlib import Path
 
@@ -53,6 +54,8 @@ def qapp():
     """Provide QApplication instance for Qt tests"""
     pytest.importorskip("PyQt6")
     from PyQt6.QtWidgets import QApplication
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
     app = QApplication.instance()
     if app is None:


### PR DESCRIPTION
## Summary
- centralize font family usage in typography utilities
- allow Qt tests to run headlessly by setting `QT_QPA_PLATFORM` in pytest fixtures

## Testing
- `pip install -r requirements.txt`
- `pip install musicbrainzngs`
- `pytest -q` *(fails: Aborted due to Qt platform issues)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e82a90c832ea5fcd1efd7bcfb43